### PR TITLE
Refactor ThemeName function to use Helper class

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -244,8 +244,7 @@ function themeInit($archive){
 		printarray(array('hidden'=>$archive->hidden));
 }
 function ThemeName(){
-	$db=Typecho_Db::get();$query=$db->select('value')->from('table.options')->where('name = ?','theme');
-	$result=$db->fetchAll($query);return $result[0]["value"];
+	return Helper::options()->theme;
 }
 function ThemePrimary(){
 	$primary=Helper::options()->themeprimary;


### PR DESCRIPTION
更直接的当前模板名获取方式，增强各种情况下兼容性比如（主题演示站：https://demo.typecho.work/?theme=MDUI2333 ），因为主题并不是启动状态，所以之前的获取方式会直接报错😁